### PR TITLE
fixed bug In file requirements.txt, delete pkg-resources==0.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,6 @@ incremental==17.5.0
 kombu==4.0.2
 Markdown==2.6.8
 msgpack-python==0.4.8
-pkg-resources==0.0.0
 postmarker==0.11.2
 psycopg2==2.7.1
 pytz==2017.2


### PR DESCRIPTION
According to https://github.com/pypa/pip/issues/4022, this is a bug resulting from Ubuntu providing incorrect metadata to pip. So, no there does not seem to be a good reason for this behaviour. I filed a follow-up bug with Ubuntu. https://bugs.launchpad.net/ubuntu/+source/python-pip/+bug/1635463

To backup the previous answer, it should be safe to remove that line from your requirements.txt. Here is an example Make file stanza that safely freezes your package list (drop in your Makefile and run with make freeze):

freeze:
    pip freeze | grep -v "pkg-resources" > requirements.txt